### PR TITLE
feat: add Intel Speed Shift (and probably AMD CPCC) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ load in real time, and make adjustments to fine tune your experience. Set it onc
 - Per-process overrides (e.g. set Steam to "performance")
 
 ✅ Configurable Daemon power interface:
-- CPU Governors, ACPI and ASPM configuration on the fly
+- CPU Governors, Intel/AMD pstate preference, ACPI and ASPM configuration on the fly
 - Power saving features similar to Laptop Mode Tools or TLP and others.
 
 ✅ Manual override via tray icon:

--- a/docs/dynamic_power_command_user_manual.md
+++ b/docs/dynamic_power_command_user_manual.md
@@ -92,6 +92,7 @@ You can and must configure exactly what happens when a profile is set, especiall
 
 **Features to be set**
 - CPU governor to be used.
+- EPP profile to set.
 - ACPI system state.
 - ASPM system state.
 All of these have a disable option per profile, in which case the daemon won't try to set this feature for the profile, and leave it to the previous set setting.
@@ -165,6 +166,11 @@ Currently there are only two user features:
   - Double‑check the **Path** and values.  
   - Ensure the entry is **Enabled**.  
   - Some paths differ across kernels and hardware.
+
+- **Energy Performance Preference** can't be found (epp profile)
+  - Check your BIOS setting for Intel Speed Shift and enable it.
+  - Make sure intel_pstate is in active in kernel cmdline (intel_pstate=active which is default).
+  - Check paths for epp, may differ across kernels or hardware.
 
 ---
 

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -69,6 +69,11 @@ Settings Config::loadSettings(const QString& path) {
                 if (hwNode["cpu_governor"]["modes"])
                     hardware.cpu_governor.modes = hwNode["cpu_governor"]["modes"].as<std::vector<std::string>>();
             }
+            if (hwNode["epp_profile"]) {
+                hardware.epp_profile.path = hwNode["epp_profile"]["path"].as<std::string>("");
+                if (hwNode["epp_profile"]["modes"])
+                    hardware.epp_profile.modes = hwNode["epp_profile"]["modes"].as<std::vector<std::string>>();
+            }
             if (hwNode["acpi_platform_profile"]) {
                 hardware.acpi_platform_profile.path = hwNode["acpi_platform_profile"]["path"].as<std::string>("");
                 if (hwNode["acpi_platform_profile"]["modes"])
@@ -86,6 +91,8 @@ Settings Config::loadSettings(const QString& path) {
                 ProfileSetting ps;
                 if (it.second["cpu_governor"])
                     ps.cpu_governor = it.second["cpu_governor"].as<std::string>("");
+                if (it.second["epp_profile"])
+                    ps.epp_profile = it.second["epp_profile"].as<std::string>("");
                 if (it.second["acpi_platform_profile"])
                     ps.acpi_platform_profile = it.second["acpi_platform_profile"].as<std::string>("");
                 if (it.second["aspm"])

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -24,12 +24,14 @@ struct HardwareSetting {
 
 struct ProfileSetting {
     std::string cpu_governor;
+    std::string epp_profile;
     std::string acpi_platform_profile;
     std::string aspm;
 };
 
 struct HardwareConfig {
     HardwareSetting cpu_governor;
+    HardwareSetting epp_profile;
     HardwareSetting acpi_platform_profile;
     HardwareSetting aspm;
 };

--- a/src/resources/dynamic_power.yaml
+++ b/src/resources/dynamic_power.yaml
@@ -10,6 +10,16 @@ hardware:
       - performance
       - powersave
       - disabled
+  epp_profile:
+    path: /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference
+    modes:
+      - default
+      - performance
+      - balance_performance
+      - balance_power
+      - power
+      - disabled
+    options_path: /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
   acpi_platform_profile:
     path: /sys/firmware/acpi/platform_profile
     options_path: /sys/firmware/acpi/platform_profile_choices
@@ -30,14 +40,17 @@ hardware:
 profiles:
   powersave:
     cpu_governor: powersave
+    epp_profile: power
     acpi_platform_profile: low-power
     aspm: powersave
   balanced:
     cpu_governor: performance
+    epp_profile: balance_power
     acpi_platform_profile: balanced
     aspm: default
   performance:
     cpu_governor: performance
+    epp_profile: performance
     acpi_platform_profile: performance
     aspm: performance
 features:

--- a/src/userctl/ProfileConfigDialog.cpp
+++ b/src/userctl/ProfileConfigDialog.cpp
@@ -19,7 +19,7 @@
 #include <yaml-cpp/yaml.h>
 
 static QStringList capKeys() {
-    return {"cpu_governor","acpi_platform_profile","aspm"};
+    return {"cpu_governor","epp_profile", "acpi_platform_profile","aspm"};
 }
 
 ProfileConfigDialog::ProfileConfigDialog(QWidget* parent, const QString& configPath)


### PR DESCRIPTION
This feature allows to set the energy performance preference for all core that support it.
Intel Speed Shift references intel_pstate. In AMD worlds it referencse  amd_pstate.